### PR TITLE
Switch to cibuildwheel and newer python versions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,16 +22,13 @@ jobs:
     - name: Install dependencies and requirements
       run: |
         python -m pip install --upgrade pip
-        python -m pip install setuptools twine
+        python -m pip install twine cibuildwheel
 
-    - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.7.1-manylinux2014_x86_64
-      with:
-        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
-        build-requirements: ''
+    - name: Build wheels
+      run: cibuildwheel --output-dir dist
 
     - name: Upload to PyPI
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: twine upload --skip-existing --repository-url https://upload.pypi.org/legacy/ dist/*-manylinux*.whl
+      run: twine upload --skip-existing dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,17 @@ requires = [
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
+archs = "auto64"
+container-engine = "docker"
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
+skip = "*musllinux*"
+
+[tool.cibuildwheel.linux]
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
+
+[tool.cibuildwheel.macos]
+repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"


### PR DESCRIPTION
`RalfG/python-wheels-manylinux-build` is deprecated (see https://github.com/RalfG/python-wheels-manylinux-build?tab=readme-ov-file), therefore switch to `cibuildwheel`.

Also build for newer python versions.